### PR TITLE
Add imm_gen module and integrate into execute

### DIFF
--- a/src/execute.v
+++ b/src/execute.v
@@ -3,7 +3,7 @@ module execute (
     input wire we,                     // Write enable for register file
     input wire [1:0] alu_op,          // ALUOp from control unit
     input wire [4:0] rs1, rs2, rd,    // Register addresses
-    input wire [31:0] imm,            // Immediate value
+    input wire [31:0] instr,          // Full instruction for immediate generation
     input wire alu_src,               // Select between register or immediate
     input wire [2:0] funct3,
     input wire funct7_5,
@@ -14,6 +14,7 @@ module execute (
 
     wire [31:0] op2;
     wire [3:0] alu_control;
+    wire [31:0] imm;
 
     // Register file
     regfile rf (
@@ -33,6 +34,12 @@ module execute (
         .funct3(funct3),
         .funct7_5(funct7_5),
         .alu_control(alu_control)
+    );
+
+    // Immediate generator
+    imm_gen imm_generator (
+        .instr(instr),
+        .imm_out(imm)
     );
 
     // ALU second operand selection

--- a/src/imm_gen.v
+++ b/src/imm_gen.v
@@ -1,0 +1,24 @@
+module imm_gen (
+    input wire [31:0] instr,
+    output reg [31:0] imm_out
+);
+    always @(*) begin
+        case (instr[6:0])
+            7'b0010011, // I-type ALU
+            7'b0000011, // Loads
+            7'b1100111: // JALR
+                imm_out = {{20{instr[31]}}, instr[31:20]};
+            7'b0100011: // S-type stores
+                imm_out = {{20{instr[31]}}, instr[31:25], instr[11:7]};
+            7'b1100011: // B-type branches
+                imm_out = {{19{instr[31]}}, instr[31], instr[7], instr[30:25], instr[11:8], 1'b0};
+            7'b0110111, // LUI
+            7'b0010111: // AUIPC
+                imm_out = {instr[31:12], 12'b0};
+            7'b1101111: // J-type JAL
+                imm_out = {{11{instr[31]}}, instr[31], instr[19:12], instr[20], instr[30:21], 1'b0};
+            default:
+                imm_out = 32'b0;
+        endcase
+    end
+endmodule

--- a/testbench/execute_tb.v
+++ b/testbench/execute_tb.v
@@ -6,7 +6,7 @@ module execute_tb;
     reg clk, we, alu_src;
     reg [1:0] alu_op;
     reg [4:0] rs1, rs2, rd;
-    reg [31:0] imm;
+    reg [31:0] instr;
     reg [2:0] funct3;
     reg funct7_5;
 
@@ -22,7 +22,7 @@ module execute_tb;
         .rs1(rs1),
         .rs2(rs2),
         .rd(rd),
-        .imm(imm),
+        .instr(instr),
         .alu_src(alu_src),
         .funct3(funct3),
         .funct7_5(funct7_5),
@@ -49,7 +49,7 @@ module execute_tb;
         alu_src = 0;           // ALU source = register
         funct3 = 3'b000;       // ADD
         funct7_5 = 0;
-        imm = 0;               // Not used for ADD
+        instr = 32'h002082b3;  // add x5, x1, x2
 
         // Initialise x1 = 10 and x2 = 15
         uut.rf.regs[1] = 32'd10;


### PR DESCRIPTION
## Summary
- generate immediates for all RV32I instruction formats
- instantiate new imm_gen in `execute.v`
- adapt `execute_tb` to supply a full instruction

## Testing
- `iverilog -o sim/execute_tb.out src/alu.v src/alu_control.v src/imm_gen.v src/regfile.v src/execute.v testbench/execute_tb.v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f973141e083329a96b09dc8d0c470