### PR TITLE
Implement branch/jump PC logic

### DIFF
--- a/src/cpu_fetch.v
+++ b/src/cpu_fetch.v
@@ -1,6 +1,15 @@
 module cpu_fetch (
-    input wire clk,
-    input wire reset,
+    input  wire        clk,
+    input  wire        reset,
+
+    // Control signals / targets
+    input  wire        jal,            // jal instruction
+    input  wire        jalr,           // jalr instruction
+    input  wire        branch,         // conditional branch instruction
+    input  wire        branch_taken,   // result of branch comparison from ALU
+    input  wire [31:0] branch_target,  // PC-relative target for jal/branch
+    input  wire [31:0] jalr_target,    // Target address for jalr
+
     output wire [31:0] instr,
     output wire [31:0] pc_out
 );
@@ -20,7 +29,12 @@ module cpu_fetch (
         .instr(instr)
     );
 
-    // PC always increments by 4 (for now, no branches)
-    assign next_pc = pc_out + 4;
+    // Next PC generation with branch/jump handling
+    wire [31:0] pc_plus4 = pc_out + 4;
+
+    assign next_pc = jal  ? branch_target :
+                     jalr ? jalr_target  :
+                     (branch && branch_taken) ? branch_target :
+                     pc_plus4;
 
 endmodule

--- a/testbench/cpu_fetch_tb.v
+++ b/testbench/cpu_fetch_tb.v
@@ -3,11 +3,19 @@
 module cpu_fetch_tb;
 
     reg clk, reset;
+    reg jal, jalr, branch, branch_taken;
+    reg [31:0] branch_target, jalr_target;
     wire [31:0] instr, pc_out;
 
     cpu_fetch uut (
         .clk(clk),
         .reset(reset),
+        .jal(jal),
+        .jalr(jalr),
+        .branch(branch),
+        .branch_taken(branch_taken),
+        .branch_target(branch_target),
+        .jalr_target(jalr_target),
         .instr(instr),
         .pc_out(pc_out)
     );
@@ -17,8 +25,23 @@ module cpu_fetch_tb;
         $dumpvars(0, cpu_fetch_tb);
 
         clk = 0; reset = 1;
+        jal = 0; jalr = 0; branch = 0; branch_taken = 0;
+        branch_target = 0; jalr_target = 0;
+
         #10 reset = 0;
-        #100 $finish;
+        // Test jal jump at time 20
+        #10 branch_target = 32'h00000020; jal = 1;
+        #10 jal = 0;
+
+        // Test jalr jump
+        #10 jalr_target = 32'h00000040; jalr = 1;
+        #10 jalr = 0;
+
+        // Test conditional branch taken
+        #10 branch = 1; branch_taken = 1; branch_target = 32'h00000060;
+        #10 branch = 0; branch_taken = 0;
+
+        #50 $finish;
     end
 
     always #5 clk = ~clk;


### PR DESCRIPTION
## Summary
- expand `cpu_fetch` with jump and branch inputs
- select next PC using `jal`, `jalr` and branch conditions
- update fetch testbench for new interface

## Testing
- `iverilog -o sim/cpu_fetch_tb.out src/pc.v src/instr_mem.v src/cpu_fetch.v testbench/cpu_fetch_tb.v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9731dabc8332b45beecaf2c7343b