### PR TITLE
Add control unit and CPU integration

### DIFF
--- a/src/control_unit.v
+++ b/src/control_unit.v
@@ -1,0 +1,65 @@
+module control_unit(
+    input  wire [6:0] opcode,
+    input  wire [2:0] funct3,
+    input  wire [6:0] funct7,
+    output reg  [1:0] ALUOp,
+    output reg  RegWrite,
+    output reg  MemRead,
+    output reg  MemWrite,
+    output reg  Branch,
+    output reg  Jump,
+    output reg  ALUSrc
+);
+
+    always @(*) begin
+        // Default values
+        ALUOp    = 2'b00;
+        RegWrite = 0;
+        MemRead  = 0;
+        MemWrite = 0;
+        Branch   = 0;
+        Jump     = 0;
+        ALUSrc   = 0;
+
+        case (opcode)
+            7'b0110011: begin // R-type
+                RegWrite = 1;
+                ALUOp    = 2'b10;
+                ALUSrc   = 0;
+            end
+            7'b0010011: begin // I-type ALU
+                RegWrite = 1;
+                ALUOp    = 2'b11;
+                ALUSrc   = 1;
+            end
+            7'b0000011: begin // Load
+                RegWrite = 1;
+                MemRead  = 1;
+                ALUOp    = 2'b00;
+                ALUSrc   = 1;
+            end
+            7'b0100011: begin // Store
+                MemWrite = 1;
+                ALUOp    = 2'b00;
+                ALUSrc   = 1;
+            end
+            7'b1100011: begin // Branch
+                Branch   = 1;
+                ALUOp    = 2'b01;
+                ALUSrc   = 0;
+            end
+            7'b1101111: begin // JAL
+                Jump     = 1;
+                RegWrite = 1;
+            end
+            7'b1100111: begin // JALR
+                Jump     = 1;
+                RegWrite = 1;
+                ALUSrc   = 1;
+                ALUOp    = 2'b00;
+            end
+            default: begin
+            end
+        endcase
+    end
+endmodule

--- a/src/cpu.v
+++ b/src/cpu.v
@@ -1,0 +1,64 @@
+module cpu(
+    input wire clk,
+    input wire reset
+);
+    wire [31:0] instr;
+    wire [31:0] pc_out;
+
+    cpu_fetch fetch_unit(
+        .clk(clk),
+        .reset(reset),
+        .instr(instr),
+        .pc_out(pc_out)
+    );
+
+    // Decode fields
+    wire [6:0] opcode = instr[6:0];
+    wire [2:0] funct3 = instr[14:12];
+    wire [6:0] funct7 = instr[31:25];
+    wire [4:0] rd  = instr[11:7];
+    wire [4:0] rs1 = instr[19:15];
+    wire [4:0] rs2 = instr[24:20];
+
+    // Immediate (I-type for now)
+    wire [31:0] imm_i = {{20{instr[31]}}, instr[31:20]};
+
+    // Control signals
+    wire [1:0] ALUOp;
+    wire RegWrite, MemRead, MemWrite, Branch, Jump, ALUSrc;
+
+    control_unit cu(
+        .opcode(opcode),
+        .funct3(funct3),
+        .funct7(funct7),
+        .ALUOp(ALUOp),
+        .RegWrite(RegWrite),
+        .MemRead(MemRead),
+        .MemWrite(MemWrite),
+        .Branch(Branch),
+        .Jump(Jump),
+        .ALUSrc(ALUSrc)
+    );
+
+    wire [31:0] alu_result;
+    wire zero;
+
+    execute exec_unit(
+        .clk(clk),
+        .we(RegWrite),
+        .alu_op(ALUOp),
+        .rs1(rs1),
+        .rs2(rs2),
+        .rd(rd),
+        .imm(imm_i),
+        .alu_src(ALUSrc),
+        .funct3(funct3),
+        .funct7_5(funct7[5]),
+        .alu_result(alu_result),
+        .zero(zero),
+        .rd1(),
+        .rd2()
+    );
+
+    // TODO: branch/jump/memory not implemented yet
+endmodule

--- a/testbench/cpu_tb.v
+++ b/testbench/cpu_tb.v
@@ -1,0 +1,20 @@
+`timescale 1ns / 1ps
+
+module cpu_tb;
+    reg clk, reset;
+
+    cpu uut (
+        .clk(clk),
+        .reset(reset)
+    );
+
+    initial begin
+        $dumpfile("sim/cpu.vcd");
+        $dumpvars(0, cpu_tb);
+        clk = 0; reset = 1;
+        #10 reset = 0;
+        #100 $finish;
+    end
+
+    always #5 clk = ~clk;
+endmodule


### PR DESCRIPTION
## Summary
- implement a new `control_unit` module for opcode decoding
- create a `cpu` top module that wires fetch, control and execute stages
- provide a small testbench for the new CPU

## Testing
- `iverilog -o sim/cpu_tb.out src/*.v testbench/cpu_tb.v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9730aebc8332ad3c2b216674f794