### PR TITLE
Add running tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ riscv_cpu/
 
 ---
 
+## 🚀 Running Tests
+
+All module and integration tests are executed using `sim/run.sh`. Ensure
+that **Icarus Verilog** and **Surfer** are installed and available in your
+`PATH` before running the scripts.
+
+```bash
+# Test the program counter
+bash sim/run.sh pc_tb
+
+# Test the instruction memory
+bash sim/run.sh instr_mem_tb
+
+# Full CPU integration test
+bash sim/run.sh cpu_integration_tb
+```
+
+---
+
 ## 🧠 Example Instruction Tested
 
 ```


### PR DESCRIPTION
## Summary
- document how to launch the testbenches
- mention the need for Icarus Verilog and Surfer

## Testing
- `bash sim/run.sh pc_tb` *(fails: iverilog and surfer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fbf0023c8332844f409e2c3a8455