### PR TITLE
Add performance counters for RISC-V CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,25 @@ bash sim/run.sh pc_tb
 bash sim/run.sh instr_mem_tb
 
 # Full CPU integration test
-bash sim/run.sh cpu_integration_tb
+bash sim/run.sh cpu_full_tb
 ```
+
+---
+
+## 📊 Benchmark Metrics
+
+The CPU tracks several performance counters during simulation:
+
+* **`cycle_count`** – total cycles executed
+* **`instr_count`** – number of instructions retired
+* **`mem_read_count`/`mem_write_count`** – load and store operations
+* **`rf_read_count`/`rf_write_count`** – register file reads and writes
+
+These values can be inspected from any testbench (e.g. `uut.instr_count`) to
+understand why a given program performs the way it does.
+
+Running `bash sim/run.sh cpu_full_tb` will print these counters when the
+program ends.
 
 ---
 

--- a/sim/run.sh
+++ b/sim/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Usage: bash sim/run.sh pc_tb
 #        bash sim/run.sh instr_mem_tb
-#        bash sim/run.sh cpu_integration_tb
+#        bash sim/run.sh cpu_full_tb
 #        bash sim/run.sh cpu_arith_tb
 
 if [ "$1" == "instr_mem_tb" ]; then
@@ -69,18 +69,17 @@ elif [ "$1" == "cpu_full_tb" ]; then
   echo "Opening waveform in Surfer..."
   surfer sim/cpu_full_tb.vcd
 else
-  echo "Usage: bash sim/run.sh [pc_tb|instr_mem_tb|cpu_integration_tb|cpu_arith_tb|cpu_reg_rw_tb|cpu_imm_bitwise_tb|cpu_mem_tb|cpu_branch_tb|cpu_jump_tb|cpu_full_tb]"
+  echo "Usage: bash sim/run.sh [pc_tb|instr_mem_tb|cpu_full_tb|cpu_arith_tb|cpu_reg_rw_tb|cpu_imm_bitwise_tb|cpu_mem_tb|cpu_branch_tb|cpu_jump_tb]"
   echo ""
   echo "Available testbenches:"
   echo "  pc_tb              - Test program counter"
   echo "  instr_mem_tb       - Test instruction memory"
-  echo "  cpu_integration_tb - Test complete CPU with all components"
+  echo "  cpu_full_tb        - Run full CPU test suite"
   echo "  cpu_arith_tb       - Test CPU arithmetic instructions"
   echo "  cpu_reg_rw_tb      - Test register reads and writes"
   echo "  cpu_imm_bitwise_tb - Test immediates and bitwise/shift ops"
   echo "  cpu_mem_tb         - Test memory access"
   echo "  cpu_branch_tb      - Test branching logic"
   echo "  cpu_jump_tb        - Test jump instructions"
-  echo "  cpu_full_tb        - Run full CPU test suite"
   exit 1
 fi

--- a/testbench/cpu_full_tb.v
+++ b/testbench/cpu_full_tb.v
@@ -26,6 +26,12 @@ module cpu_full_tb;
         .cycle_count(cycle_count)
     );
 
+    wire [31:0] instr_count      = uut.instr_count;
+    wire [31:0] mem_read_count   = uut.mem_read_count;
+    wire [31:0] mem_write_count  = uut.mem_write_count;
+    wire [31:0] rf_read_count    = uut.rf_read_count;
+    wire [31:0] rf_write_count   = uut.rf_write_count;
+
     // 10ns clock
     always #5 clk = ~clk;
 
@@ -90,6 +96,11 @@ module cpu_full_tb;
         $display("Passed       : %0d", pass_count);
         $display("Failed       : %0d", fail_count);
         $display("Cycles       : %0d", cycle_count);
+        $display("Instructions : %0d", instr_count);
+        $display("Mem reads    : %0d", mem_read_count);
+        $display("Mem writes   : %0d", mem_write_count);
+        $display("RF reads     : %0d", rf_read_count);
+        $display("RF writes    : %0d", rf_write_count);
         $finish;
     end
 endmodule


### PR DESCRIPTION
## Summary
- implement instruction, memory, and register-file counters in `cpu.v`
- document new metrics in README
- hint at future power estimation support
- print all counters from `cpu_full_tb`
- update README run instructions
- clean up `sim/run.sh` usage for the full CPU testbench

## Testing
- `bash sim/run.sh cpu_full_tb` *(fails: iverilog not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597762d3e08332a9227937f5662aec