### PR TITLE
Extend benchmark testbenches with more metrics

### DIFF
--- a/testbench/cpu_dotprod_tb.v
+++ b/testbench/cpu_dotprod_tb.v
@@ -4,6 +4,11 @@ module cpu_dotprod_tb;
     reg clk = 0;
     reg reset;
     wire [31:0] cycle_count;
+    wire [31:0] instr_count      = uut.instr_count;
+    wire [31:0] mem_read_count   = uut.mem_read_count;
+    wire [31:0] mem_write_count  = uut.mem_write_count;
+    wire [31:0] rf_read_count    = uut.rf_read_count;
+    wire [31:0] rf_write_count   = uut.rf_write_count;
 
     cpu #(.MEMFILE("test_mem/dotprod.mem")) uut (
         .clk(clk),
@@ -23,7 +28,12 @@ module cpu_dotprod_tb;
 
         repeat(40) @(posedge clk); #1;
         $display("Dot product result: %0d", uut.exec_unit.rf.regs[8]);
-        $display("Cycles: %0d", cycle_count);
+        $display("Cycles       : %0d", cycle_count);
+        $display("Instructions : %0d", instr_count);
+        $display("Mem reads    : %0d", mem_read_count);
+        $display("Mem writes   : %0d", mem_write_count);
+        $display("RF reads     : %0d", rf_read_count);
+        $display("RF writes    : %0d", rf_write_count);
         $finish;
     end
 endmodule

--- a/testbench/cpu_matmul_tb.v
+++ b/testbench/cpu_matmul_tb.v
@@ -4,6 +4,11 @@ module cpu_matmul_tb;
     reg clk = 0;
     reg reset;
     wire [31:0] cycle_count;
+    wire [31:0] instr_count      = uut.instr_count;
+    wire [31:0] mem_read_count   = uut.mem_read_count;
+    wire [31:0] mem_write_count  = uut.mem_write_count;
+    wire [31:0] rf_read_count    = uut.rf_read_count;
+    wire [31:0] rf_write_count   = uut.rf_write_count;
 
     cpu #(.MEMFILE("test_mem/matmul.mem")) uut (
         .clk(clk),
@@ -27,7 +32,12 @@ module cpu_matmul_tb;
                  uut.exec_unit.rf.regs[12],
                  uut.exec_unit.rf.regs[13],
                  uut.exec_unit.rf.regs[14]);
-        $display("Cycles: %0d", cycle_count);
+        $display("Cycles       : %0d", cycle_count);
+        $display("Instructions : %0d", instr_count);
+        $display("Mem reads    : %0d", mem_read_count);
+        $display("Mem writes   : %0d", mem_write_count);
+        $display("RF reads     : %0d", rf_read_count);
+        $display("RF writes    : %0d", rf_write_count);
         $finish;
     end
 endmodule

--- a/testbench/cpu_relu_tb.v
+++ b/testbench/cpu_relu_tb.v
@@ -4,6 +4,11 @@ module cpu_relu_tb;
     reg clk = 0;
     reg reset;
     wire [31:0] cycle_count;
+    wire [31:0] instr_count      = uut.instr_count;
+    wire [31:0] mem_read_count   = uut.mem_read_count;
+    wire [31:0] mem_write_count  = uut.mem_write_count;
+    wire [31:0] rf_read_count    = uut.rf_read_count;
+    wire [31:0] rf_write_count   = uut.rf_write_count;
 
     cpu #(.MEMFILE("test_mem/relu.mem")) uut (
         .clk(clk),
@@ -25,7 +30,12 @@ module cpu_relu_tb;
         $display("Result memory: %0d %0d %0d %0d",
                  uut.dmem.mem[0], uut.dmem.mem[1],
                  uut.dmem.mem[2], uut.dmem.mem[3]);
-        $display("Cycles: %0d", cycle_count);
+        $display("Cycles       : %0d", cycle_count);
+        $display("Instructions : %0d", instr_count);
+        $display("Mem reads    : %0d", mem_read_count);
+        $display("Mem writes   : %0d", mem_write_count);
+        $display("RF reads     : %0d", rf_read_count);
+        $display("RF writes    : %0d", rf_write_count);
         $finish;
     end
 endmodule


### PR DESCRIPTION
## Summary
- expose CPU performance counters in dot product, matrix multiplication and ReLU benchmarks
- display instruction, memory and register metrics in these benches

## Testing
- `bash sim/run.sh cpu_dotprod_tb` *(fails: iverilog not found)*
- `bash sim/run.sh cpu_matmul_tb` *(fails: iverilog not found)*
- `bash sim/run.sh cpu_relu_tb` *(fails: iverilog not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd2bc5e74833287740d4c04b21a5f