### PR TITLE
Fix run scripts to work from repo root

### DIFF
--- a/accel_cpu/sim/run.sh
+++ b/accel_cpu/sim/run.sh
@@ -4,6 +4,11 @@
 #        bash sim/run.sh cpu_full_tb
 #        bash sim/run.sh cpu_arith_tb
 
+# Ensure the script can be executed from any directory by
+# switching to the CPU root (one level above this script).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
 if [ "$1" == "instr_mem_tb" ]; then
   iverilog -o sim/instr_mem_tb.out src/instr_mem.v testbench/instr_mem_tb.v
   vvp sim/instr_mem_tb.out

--- a/base_cpu/sim/run.sh
+++ b/base_cpu/sim/run.sh
@@ -4,6 +4,11 @@
 #        bash sim/run.sh cpu_full_tb
 #        bash sim/run.sh cpu_arith_tb
 
+# Ensure the script can be executed from any directory by
+# switching to the CPU root (one level above this script).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
 if [ "$1" == "instr_mem_tb" ]; then
   iverilog -o sim/instr_mem_tb.out src/instr_mem.v testbench/instr_mem_tb.v
   vvp sim/instr_mem_tb.out


### PR DESCRIPTION
## Summary
- run.sh scripts assumed the working directory was the CPU folder which led to missing file errors
- update both run.sh scripts to change into their parent directory automatically

## Testing
- `bash accel_cpu/sim/run.sh cpu_relu_tb` *(fails: `iverilog: command not found`)*
- `bash base_cpu/sim/run.sh cpu_matmul_tb` *(fails: `iverilog: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863290d230c8332a3e62a0ab07f0575