### PR TITLE
Fix run.sh path handling

### DIFF
--- a/accel_cpu/sim/run.sh
+++ b/accel_cpu/sim/run.sh
@@ -4,6 +4,11 @@
 #        bash sim/run.sh cpu_full_tb
 #        bash sim/run.sh cpu_arith_tb
 
+# Ensure script runs from its parent directory so relative paths resolve
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CPU_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$CPU_DIR" || exit 1
+
 if [ "$1" == "instr_mem_tb" ]; then
   iverilog -o sim/instr_mem_tb.out src/instr_mem.v testbench/instr_mem_tb.v
   vvp sim/instr_mem_tb.out

--- a/base_cpu/sim/run.sh
+++ b/base_cpu/sim/run.sh
@@ -4,6 +4,11 @@
 #        bash sim/run.sh cpu_full_tb
 #        bash sim/run.sh cpu_arith_tb
 
+# Ensure script runs from its parent directory so relative paths resolve
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CPU_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$CPU_DIR" || exit 1
+
 if [ "$1" == "instr_mem_tb" ]; then
   iverilog -o sim/instr_mem_tb.out src/instr_mem.v testbench/instr_mem_tb.v
   vvp sim/instr_mem_tb.out


### PR DESCRIPTION
## Summary
- make run.sh scripts change to their parent directory first

## Testing
- `bash accel_cpu/sim/run.sh cpu_relu_tb > /tmp/accel_relu.log 2>&1 && tail -n 20 /tmp/accel_relu.log`
- `bash base_cpu/sim/run.sh cpu_relu_tb > /tmp/base_relu.log 2>&1 && tail -n 20 /tmp/base_relu.log`


------
https://chatgpt.com/codex/tasks/task_e_6863290d230c8332a3e62a0ab07f0575